### PR TITLE
Don't remove exists error config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ That's all! :tada:
 
 ### Advanced Usage
 
+#### Configure logger
+You can config this plugin's logger with `sentry_log`. As below.
+```php
+// in config/app.php
+'Log' => [
+    'sentry_log' => [
+        'className' => 'CakeSentry.Sentry',
+        'levels' => ['emergency', 'alert', 'critical', 'error']
+    ],
+]
+```
+
+If you don't set `sentry_log` config, the plugin will copy your `error` and overwrite `className` to SentryLog.
+
 #### Ignore noisy exceptions
 You can filter out exceptions that make a fuss and harder to determine the issues to address(like PageNotFoundException)
 Set exceptions not to log in `Error.skipLog`.  

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -18,10 +18,11 @@ if ($isCli) {
     (new ErrorHandler(Configure::read('Error')))->register();
 }
 
-$errorLogConfig = Log::getConfig('error');
-$errorLogConfig['className'] = SentryLog::class;
-Log::drop('error');
-Log::setConfig('error', $errorLogConfig);
+if (!Log::getConfig('sentry_log')) {
+    $errorLogConfig = (array)Log::getConfig('error');
+    $errorLogConfig['className'] = SentryLog::class;
+    Log::setConfig('sentry_log', $errorLogConfig);
+}
 
 $appClass = Configure::read('App.namespace') . '\Application';
 if (class_exists($appClass)) {


### PR DESCRIPTION
If error log-config is already exists, respect it.

* the new config is named as `sentry_log` 
    * you can set it manually, then plugin will not overwrite and use it
* copy from error log-config values and set new config
* don't drop error log-config no more. these will work cooperatively each other

to: 2.0.0-alpha1