### PR TITLE
Improve ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
 
 before_script:
   - if [[ $TRAVIS_PHP_VERSION != '7.4snapshot' ]]; then phpenv config-rm xdebug.ini; fi
+  # @see https://github.com/cakephp/cakephp/commit/249cbc3d3a00e9eca931f44ee6990312f156e6cc#diff-4dafde5c48406484f186b8294c20e12c
+  - if [[ $TRAVIS_PHP_VERSION = 7.3 && $PREFER_LOWEST = '--prefer-lowest' ]]; then composer require cakephp/cakephp:3.6.13; fi
   - composer update --prefer-dist --no-interaction $PREFER_LOWEST
   - composer show -i
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - |
     if [[ $STAN = 1 ]]; then
       composer cs-check
-      vendor/bin/phpstan
+      vendor/bin/phpstan analyse
     fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,29 @@ cache:
     - vendor
     - $HOME/.composer/cache
 
+env:
+  global:
+    - PREFER_LOWEST="--prefer-lowest" TEST=1 CODECOV=0 STAN=0
+
+matrix:
+  include:
+    - php: 7.3
+      env: PREFER_LOWEST="" TEST=1 CODECOV=1 STAN=1
+    - php: "7.4snapshot"
+      env: PREFER_LOWEST="" TEST=1 CODECOV=0 STAN=0
+
 before_script:
-  - composer install --prefer-dist --no-interaction
+  - if [[ $TRAVIS_PHP_VERSION != '7.4snapshot' ]]; then phpenv config-rm xdebug.ini; fi
+  - composer update --prefer-dist --no-interaction $PREFER_LOWEST
 
 script:
-  - composer cs-check
-  - vendor/bin/phpunit --coverage-clover=clover.xml
-  - vendor/bin/phpstan
+  - if [[ $TEST = 1 && $CODECOV = 0 ]]; then vendor/bin/phpunit; fi
+  - if [[ $TEST = 1 && $CODECOV = 1 ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
+  - |
+    if [[ $STAN = 1 ]]; then
+      composer cs-check
+      vendor/bin/phpstan
+    fi
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - if [[ $TEST = 1 && $CODECOV = 1 ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
 before_script:
   - if [[ $TRAVIS_PHP_VERSION != '7.4snapshot' ]]; then phpenv config-rm xdebug.ini; fi
   - composer update --prefer-dist --no-interaction $PREFER_LOWEST
+  - composer show -i
 
 script:
   - if [[ $TEST = 1 && $CODECOV = 0 ]]; then vendor/bin/phpunit; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 script:
   - composer cs-check
   - vendor/bin/phpunit --coverage-clover=clover.xml
-  - vendor/bin/phpstan analyse src -l 2
+  - vendor/bin/phpstan
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "dereuromark/cakephp-ide-helper": "^0.10.3",
         "jangregor/phpstan-prophecy": "^0.4.2",
         "phpstan/phpstan": "@stable",
-        "phpunit/phpunit": "^6.4"
+        "phpunit/phpunit": "^6.4|^7.0"
     },
     "license": "MIT",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,9 @@
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",
         "dereuromark/cakephp-ide-helper": "^0.10.3",
-        "phpunit/phpunit": "^6.4",
-        "phpstan/phpstan": "^0.9.2"
+        "jangregor/phpstan-prophecy": "^0.4.2",
+        "phpstan/phpstan": "@stable",
+        "phpunit/phpunit": "^6.4"
     },
     "license": "MIT",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",
-        "dereuromark/cakephp-ide-helper": "^0.10.3",
         "jangregor/phpstan-prophecy": "^0.4.2",
         "phpstan/phpstan": "@stable",
         "phpunit/phpunit": "^6.4|^7.0"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^7.1",
         "cakephp/cakephp": "^3.6",
         "sentry/sdk": "^2.0",
-        "sentry/sentry": "^2.1"
+        "sentry/sentry": "^2.2"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -8,6 +8,9 @@ use Connehito\CakeSentry\Error\ErrorHandler;
 use Connehito\CakeSentry\Log\Engine\SentryLog;
 
 $isCli = PHP_SAPI === 'cli';
+if (!$isCli && strpos((env('argv')[0] ?? ''), '/phpunit') !== false) {
+    $isCli = true;
+}
 if ($isCli) {
     (new ConsoleErrorHandler(Configure::read('Error')))->register();
 } else {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+includes:
+- vendor/jangregor/phpstan-prophecy/src/extension.neon
+parameters:
+    paths:
+      - src
+      - tests/TestCase
+    level: 5
+    autoload_files:
+      - tests/bootstrap.php
+      - tests/TestCase/Error/SentryErrorHandlerTraitTest.php # for including stub class

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,6 @@
     colors="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
     bootstrap="./tests/bootstrap.php"
     backupGlobals="true"
     >

--- a/tests/TestCase/Error/SentryErrorHandlerTraitTest.php
+++ b/tests/TestCase/Error/SentryErrorHandlerTraitTest.php
@@ -37,7 +37,7 @@ final class Stub
     }
 }
 
-class SentryErrorHandlerTraitTest extends TestCase
+final class SentryErrorHandlerTraitTest extends TestCase
 {
     /** @var Stub test subject */
     private $subject;

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -173,6 +173,12 @@ final class ClientTest extends TestCase
      */
     public function testCaptureErrorBuildBreadcrumbs()
     {
+        $stacks = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT);
+        $expect = [
+            'file' => $stacks[2]['file'],
+            'line' => $stacks[2]['line'],
+        ];
+
         $subject = new Client([]);
         $sentryClientP = $this->prophesize(ClientInterface::class);
         $sentryClientP->getOptions()
@@ -199,12 +205,6 @@ final class ClientTest extends TestCase
             ->shouldBeCalled();
         $subject->getHub()->bindClient($sentryClientP->reveal());
 
-        $stack = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT);
-        $stack = array_slice($stack, 2);
-        $expect = [
-            'file' => $stack[0]['file'],
-            'line' => $stack[0]['line'],
-        ];
         $subject->capture(
             'warning',
             'some error',

--- a/tests/TestCase/PluginTest.php
+++ b/tests/TestCase/PluginTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Connehito\CakeSentry\Test;
+namespace Connehito\CakeSentry\Test\TestCase;
 
 use Cake\Error\Middleware\ErrorHandlerMiddleware as CakeErrorHandlerMiddleware;
 use Cake\Http\MiddlewareQueue;


### PR DESCRIPTION
- run tests with "lowest" ver. packages
    - check if the plugin run in lower ver(min:3.6+)
- run on PHP7.4snapshot
- generate code coverage using phpdbg
- phpstan lv.5
    - create phpstan.neon
    - addingTestCase dir to analyze target.