### PR TITLE
#23 Fix Invalid `before_send` injection

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -108,12 +108,6 @@ class Client
         if (!Hash::check($config, 'dsn')) {
             throw new RuntimeException('Sentry DSN not provided.');
         }
-        if (!Hash::get($config, 'before_send')) {
-            $config['before_send'] = function () {
-                $event = new Event('CakeSentry.Client.afterCapture', $this, func_get_args());
-                $this->getEventManager()->dispatch($event);
-            };
-        }
 
         init($config);
         $this->hub = SentrySdk::getCurrentHub();

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -7,7 +7,9 @@ use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\Http\Exception\NotFoundException;
 use Cake\TestSuite\TestCase;
+use Closure;
 use Connehito\CakeSentry\Http\Client;
+use Exception;
 use Prophecy\Argument;
 use ReflectionProperty;
 use RuntimeException;
@@ -102,7 +104,7 @@ final class ClientTest extends TestCase
             ->getBeforeSendCallback();
 
         $this->assertInstanceOf(
-            \Closure::class,
+            Closure::class,
             $actual
         );
     }
@@ -242,7 +244,7 @@ final class ClientTest extends TestCase
         $subject->capture(
             'info',
             'some error',
-            ['exception' => new \Exception()]
+            ['exception' => new Exception()]
         );
 
         $this->assertTrue($called);
@@ -276,7 +278,7 @@ final class ClientTest extends TestCase
         $subject->capture(
             'info',
             'some error',
-            ['exception' => new \Exception()]
+            ['exception' => new Exception()]
         );
 
         $this->assertTrue($called);

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -65,6 +65,14 @@ final class ClientTest extends TestCase
     public function testSetupClientSetOptions()
     {
         Configure::write('Sentry.excluded_exceptions', [NotFoundException::class]);
+        $beforeSend = (new class
+        {
+            public function __invoke()
+            {
+                return true;
+            }
+        });
+        Configure::write('Sentry.before_send', $beforeSend);
 
         $subject = new Client([]);
         $options = $subject->getHub()->getClient()->getOptions();
@@ -72,6 +80,10 @@ final class ClientTest extends TestCase
         $this->assertSame(
             [NotFoundException::class],
             $options->getExcludedExceptions()
+        );
+        $this->assertSame(
+            get_class($beforeSend),
+            get_class($options->getBeforeSendCallback())
         );
     }
 

--- a/tests/test_app/app/src/Error/Event/SentryErrorContext.php
+++ b/tests/test_app/app/src/Error/Event/SentryErrorContext.php
@@ -17,7 +17,7 @@ class SentryErrorContext implements EventListenerInterface
         return [
             'CakeSentry.Client.afterSetup' => 'setServerContext',
             'CakeSentry.Client.beforeCapture' => 'setContext',
-            //'CakeSentry.Client.afterCapture' => 'callbackAfterCapture(',
+            //'CakeSentry.Client.afterCapture' => 'callbackAfterCapture',
         ];
     }
 


### PR DESCRIPTION
https://github.com/Connehito/cake-sentry/issues/23

Configure `Sentry.before_send` is the option to set in Sentry-SDK's BeforeSendCallback.
And `CakeSentry.Client.beforeCapture` event is called in Client::capture() in first.
So, the two are completely different.

`Sentry.before_send` sholud not pub `beforeCapture`.