### PR TITLE
#25 - Cake 4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ CakePHP integration for Sentry.
 [![License](https://poser.pugx.org/connehito/cake-sentry/license)](https://packagist.org/packages/connehito/cake-sentry)
 
 ## Requirements
-- PHP 7.1+
-- CakePHP 3.6+
+- PHP 7.2+
+- CakePHP 4.0+
 - and [Sentry](https://sentry.io) account
 
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "cakephp-plugin",
     "require": {
         "php": "^7.1",
-        "cakephp/cakephp": "^3.6|^4.0",
+        "cakephp/cakephp": "^4.0",
         "sentry/sdk": "^2.0",
         "sentry/sentry": "^2.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "cakephp-plugin",
     "require": {
         "php": "^7.1",
-        "cakephp/cakephp": "^3.6",
+        "cakephp/cakephp": "^3.6|^4.0",
         "sentry/sdk": "^2.0",
         "sentry/sentry": "^2.2"
     },

--- a/src/Error/SentryErrorHandlerTrait.php
+++ b/src/Error/SentryErrorHandlerTrait.php
@@ -33,7 +33,7 @@ trait SentryErrorHandlerTrait
      * @param array $data Array of error data.
      * @return bool
      */
-    protected function _logError($level, $data)
+    protected function _logError($level, array $data): bool
     {
         $error = new ErrorException($data['description'], 0, $data['code'], $data['file'], $data['line']);
 

--- a/src/Error/SentryErrorHandlerTrait.php
+++ b/src/Error/SentryErrorHandlerTrait.php
@@ -13,60 +13,6 @@ trait SentryErrorHandlerTrait
 {
     use InstanceConfigTrait;
 
-    /**
-     * Generates a formatted error message with exception.
-     *
-     * @see \Cake\Error\BaseErrorHandler::_getMessage()
-     *
-     * @param Exception $exception subject
-     * @return string Formatted message
-     */
-    abstract protected function _getMessage(Exception $exception);
-
     /* @var Client */
     protected $client;
-
-    /**
-     * Change error messages into ErrorException and write exception log.
-     *
-     * @param string $level The level name of the log.
-     * @param array $data Array of error data.
-     * @return bool
-     */
-    protected function _logError($level, array $data): bool
-    {
-        $error = new ErrorException($data['description'], 0, $data['code'], $data['file'], $data['line']);
-
-        return Log::write($level, $this->_getMessage($error), ['exception' => $error]);
-    }
-
-    /**
-     * Handles exception logging.
-     *
-     * @param Exception $exception Exception instance.
-     * @return bool
-     */
-    protected function _logException(Exception $exception)
-    {
-        $config = $this->_options;
-
-        $unwrapped = $exception instanceof PHP7ErrorException ?
-            $exception->getError() :
-            $exception;
-
-        if (empty($config['log'])) {
-            return false;
-        }
-        if (!empty($config['skipLog'])) {
-            foreach ((array)$config['skipLog'] as $class) {
-                if ($unwrapped instanceof $class) {
-                    return false;
-                }
-            }
-        }
-
-        $message = $this->_getMessage($exception);
-
-        return Log::error($message, compact('exception'));
-    }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,7 +12,7 @@ class Plugin extends BasePlugin
     /**
      * {@inheritDoc}
      */
-    public function middleware(MiddlewareQueue $middleware)
+    public function middleware(MiddlewareQueue $middleware): MiddlewareQueue
     {
         $middleware = parent::middleware($middleware);
         $middleware->insertAfter(

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -3,6 +3,7 @@
 namespace Connehito\CakeSentry;
 
 use Cake\Core\BasePlugin;
+use Cake\Http\MiddlewareQueue;
 use Cake\Error\Middleware\ErrorHandlerMiddleware as CakeErrorHandlerMiddleware;
 use Connehito\CakeSentry\Error\Middleware\ErrorHandlerMiddleware;
 
@@ -11,7 +12,7 @@ class Plugin extends BasePlugin
     /**
      * {@inheritDoc}
      */
-    public function middleware($middleware)
+    public function middleware(MiddlewareQueue $middleware)
     {
         $middleware = parent::middleware($middleware);
         $middleware->insertAfter(


### PR DESCRIPTION
Some rough draft of cake 4 support.

I tested it and it works. It should probably be a new Major release, because it requires another major version of CakePHP.

I did not quite understand the Intent of your overrides to the BaseErrorHandler. In Cake 4, the internals of it changed quite a bit (no `_getMessage()` exists any more, among others), so to get it working for now on my branch, i removed the overrides. Feel free to readd them, you know best what their intent was.

