### PR TITLE
Fix client setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^7.1",
         "cakephp/cakephp": "^3.6",
-        "sentry/sdk": "^2.0",
+        "php-http/guzzle6-adapter": "^v1.1.1|^v2.0",
         "sentry/sentry": "^2.2"
     },
     "require-dev": {

--- a/tests/test_app/app/src/Controller/PagesController.php
+++ b/tests/test_app/app/src/Controller/PagesController.php
@@ -46,7 +46,7 @@ class PagesController extends AppController
         $message = $this->getRequest()->getQuery('message', 'error!');
         trigger_error($message, $gottenError);
 
-        $this->set(compact('gottenError', 'errorName', 'errorCode', 'message', ));
+        $this->set(compact('gottenError', 'errorName', 'errorCode', 'message'));
 
         $this->setResponse(
             $this->getResponse()->withStatus($errorCode)


### PR DESCRIPTION
guzzle6-adapter(via sentry/sdk) is broken.
cf: https://github.com/php-http/guzzle6-adapter/commit/594cd47fb9af5c217f0e63c4e8f7602da88a368a

To avoid this problem, require php-http/guzzle6-adapter directory to use v1.1.1+ and remove sentry/sdk.