### PR TITLE
Run code sniffer on actions

### DIFF
--- a/.github/workflows/php-cs.yml
+++ b/.github/workflows/php-cs.yml
@@ -1,0 +1,23 @@
+name: PHP Code Sniffer
+on:
+  pull_request:
+    paths: ["**.php"]
+
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        uses: actions/checkout@v2
+      -
+        name: "Setup PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: none
+          php-version: "7.4"
+      -
+        name: "Install phpcs"
+        run: "composer require squizlabs/php_codesniffer"
+      -
+        name: "Run phpcs"
+        run: "composer cs-check"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ script:
   - if [[ $TEST = 1 && $CODECOV = 1 ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
   - |
     if [[ $STAN = 1 ]]; then
-      composer cs-check
       vendor/bin/phpstan analyse
     fi
 


### PR DESCRIPTION
CI code sniffer is now broken.
If PHPCS detects any errors, the status is still "green". So, it must be corrected to report the error.

As a first step, I moved on from PHPCS.