### PR TITLE
Rename error handler trait

### DIFF
--- a/src/Error/ConsoleErrorHandler.php
+++ b/src/Error/ConsoleErrorHandler.php
@@ -6,5 +6,5 @@ use Cake\Error\ConsoleErrorHandler as CakeConsoleErrorHandler;
 
 class ConsoleErrorHandler extends CakeConsoleErrorHandler
 {
-    use SentryErrorHandlerTrait;
+    use ErrorHandlerTrait;
 }

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -5,5 +5,5 @@ use Cake\Error\ErrorHandler as CakeErrorHandler;
 
 class ErrorHandler extends CakeErrorHandler
 {
-    use SentryErrorHandlerTrait;
+    use ErrorHandlerTrait;
 }

--- a/src/Error/ErrorHandlerTrait.php
+++ b/src/Error/ErrorHandlerTrait.php
@@ -6,7 +6,7 @@ use Cake\Core\InstanceConfigTrait;
 use Connehito\CakeSentry\Http\Client;
 use ErrorException;
 
-trait SentryErrorHandlerTrait
+trait ErrorHandlerTrait
 {
     /**
      * Change error messages into ErrorException and write exception log.

--- a/tests/TestCase/Error/ErrorHandlerTraitTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTraitTest.php
@@ -5,12 +5,12 @@ namespace Connehito\CakeSentry\Test\TestCase\Error;
 
 use Cake\Error\ErrorHandler;
 use Cake\TestSuite\TestCase;
-use Connehito\CakeSentry\Error\SentryErrorHandlerTrait;
+use Connehito\CakeSentry\Error\ErrorHandlerTrait;
 use ErrorException;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
-final class SentryErrorHandlerTraitTest extends TestCase
+final class ErrorHandlerTraitTest extends TestCase
 {
     /**
      * test for _logError()
@@ -39,13 +39,13 @@ final class SentryErrorHandlerTraitTest extends TestCase
     }
 
     /**
-     * Get instance of SentryErrorHandlerTrait implementation
+     * Get instance of ErrorHandlerTrait implementation
      */
     private function getSubject()
     {
         $subject = new class extends ErrorHandler
         {
-            use SentryErrorHandlerTrait {
+            use ErrorHandlerTrait {
                 _logError as originalLogError;
             }
 


### PR DESCRIPTION
Only ErrorHandlerTrait had a prefix, so for consistency, removed the prefix "Sentry" like the other classes.