### PR TITLE
Sentry DSN must contain a project ID

### DIFF
--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -30,7 +30,7 @@ final class ClientTest extends TestCase
     {
         parent::setUp();
 
-        Configure::write('Sentry.dsn', 'https://user:pass@example.com/yourproject');
+        Configure::write('Sentry.dsn', 'https://yourtoken@example.com/yourproject/1');
     }
 
     /**

--- a/tests/TestCase/Log/Engine/SentryLogTest.php
+++ b/tests/TestCase/Log/Engine/SentryLogTest.php
@@ -21,7 +21,7 @@ final class SentryLogTest extends TestCase
     {
         parent::setUp();
 
-        Configure::write('Sentry.dsn', 'https://user:pass@example.com/yourproject');
+        Configure::write('Sentry.dsn', 'https://yourtoken@example.com/yourproject/1');
         $subject = new SentryLog([]);
 
         $clientMock = $this->createMock(Client::class);


### PR DESCRIPTION
Fix #46

sentry/sentry has tighter DSN validation since v2.4.0.
ref. https://github.com/getsentry/sentry-php/commit/b464c3430d4fc7e0cd513362e227a0079fbcf82d#diff-70f919637217475d1b8feca557c8cf9cR102-R106

So, I added the dummy ProjectID to the end of the DSN.