### PR TITLE
Fix CI error in job for prefer-lowest packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ matrix:
 
 before_script:
   - phpenv config-rm xdebug.ini
-  # @see https://github.com/cakephp/cakephp/commit/249cbc3d3a00e9eca931f44ee6990312f156e6cc#diff-4dafde5c48406484f186b8294c20e12c
-  - if [[ $TRAVIS_PHP_VERSION = 7.3 && $PREFER_LOWEST = '--prefer-lowest' ]]; then composer require cakephp/cakephp:3.6.13; fi
-  # @see https://github.com/cakephp/cakephp/commit/e78bd7f18f6e8fb237593477cd42b6de5f4fa7f5
-  - if [[ $TRAVIS_PHP_VERSION = 7.4 && $PREFER_LOWEST = '--prefer-lowest' ]]; then composer require cakephp/cakephp:3.8.3; fi
   - composer update --prefer-dist --no-interaction $PREFER_LOWEST
+  # @see https://github.com/cakephp/cakephp/commit/249cbc3d3a00e9eca931f44ee6990312f156e6cc#diff-4dafde5c48406484f186b8294c20e12c
+  - if [[ $TRAVIS_PHP_VERSION = 7.3 && $PREFER_LOWEST = '--prefer-lowest' ]]; then composer require --prefer-lowest cakephp/cakephp:3.6.13; fi
+  # @see https://github.com/cakephp/cakephp/commit/e78bd7f18f6e8fb237593477cd42b6de5f4fa7f5
+  - if [[ $TRAVIS_PHP_VERSION = 7.4 && $PREFER_LOWEST = '--prefer-lowest' ]]; then composer require --prefer-lowest cakephp/cakephp:3.8.3; fi
   - composer show -i
   # @see https://github.com/cakephp/cakephp/pull/13567#issuecomment-525844184
   # And for old prophecy(in prefer-lowest build)


### PR DESCRIPTION
To fix cron build failure like https://travis-ci.org/github/Connehito/cake-sentry/jobs/708657380 

## What happened
As a result of the last build, each package remains in the cache with a non-prefer-lowest mode of dependency resolution.
This caused a situation where the version of PHPUnit conflicts with the version of PHPUnit when doing a downgrade of CakePHP.
The failure of the Composer's command made CI build an error.


## What I do

To do prefer-lowest dependency resolution first, so that CakePHP downgrade can be done