### PR TITLE
Ignore json exception

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -86,7 +86,11 @@ class Client
                     $stack
                 ));
             }
-            $lastEventId = $this->hub->captureMessage($message, $severity);
+            try {
+                $lastEventId = $this->hub->captureMessage($message, $severity);
+            } catch (\Sentry\Exception\JsonException $e) {
+                // Do nothing
+            }
         }
 
         $context['lastEventId'] = $lastEventId;

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -64,6 +64,8 @@ class Client
         $event = new Event('CakeSentry.Client.beforeCapture', $this, $context);
         $this->getEventManager()->dispatch($event);
 
+        $lastEventId = '';
+
         $exception = Hash::get($context, 'exception');
         if ($exception) {
             $lastEventId = $this->hub->captureException($exception);


### PR DESCRIPTION
I am getting below error and the entire script dies with:

```
Could not encode value into JSON format. An error was: "Recursion detected".
Sentry\Exception\JsonException
```

I want to ignore JsonException error.