### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^7.2",
         "cakephp/cakephp": "^4.0",
         "php-http/guzzle6-adapter": "^v1.1.1|^v2.0",
-        "sentry/sentry": "^2.2"
+        "sentry/sentry": "^2.2|^3.0"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",


### PR DESCRIPTION
Widen the version scope of the sentry sdk dependency to include 3.x. It is api compatible to 2.x as long as you do not use internal APIs which this project doesn't