### PR TITLE
Updated composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "androideo/cake-sentry",
+    "name": "connehito/cake-sentry",
     "description": "Sentry plugin for CakePHP3",
     "type": "cakephp-plugin",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^7.1",
         "cakephp/cakephp": "^3.6",
         "php-http/guzzle6-adapter": "^v1.1.1|^v2.0",
-        "sentry/sentry": "^2.2"
+        "sentry/sentry": "^2.2|^3.0"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "connehito/cake-sentry",
+    "name": " androideo/cake-sentry",
     "description": "Sentry plugin for CakePHP3",
     "type": "cakephp-plugin",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": " androideo/cake-sentry",
+    "name": "androideo/cake-sentry",
     "description": "Sentry plugin for CakePHP3",
     "type": "cakephp-plugin",
     "require": {


### PR DESCRIPTION
Widen the version scope of the sentry sdk dependency to include 3.x. It is api compatible to 2.x as long as you do not use internal APIs which this project doesn't