### PR TITLE
Upgrade sentry-php to 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,14 @@
     "require": {
         "php": "^7.2",
         "cakephp/cakephp": "^4.0",
-        "php-http/guzzle6-adapter": "^v1.1.1|^v2.0",
-        "sentry/sentry": "^2.2"
+        "sentry/sentry": "^3.0"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",
         "jangregor/phpstan-prophecy": "^0.4.2",
         "phpstan/phpstan": "@stable",
-        "phpunit/phpunit": "^8.5.0"
+        "phpunit/phpunit": "^8.5.0",
+        "symfony/http-client": "^5.2"
     },
     "license": "MIT",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "sentry/sentry": "^3.0"
     },
     "require-dev": {
-        "cakephp/cakephp-codesniffer": "^3.0",
+        "cakephp/cakephp-codesniffer": "@stable",
         "jangregor/phpstan-prophecy": "^0.4.2",
         "phpstan/phpstan": "@stable",
         "phpunit/phpunit": "^8.5.0",

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -125,7 +125,7 @@ class Client
      * key: IntegrationClassName, value: Options
      *
      * @example $integrationConfig = [IgnoreErrorsIntegration => ['ignore_exceptions' => \RuntimeException::class]]
-     * @param array<string, array> $integrationConfig
+     * @param array<string, array> $integrationConfig Integration with options map
      * @return array<IntegrationInterface>
      */
     protected function buildIntegrations(array $integrationConfig): array

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -10,6 +10,7 @@ use Cake\Utility\Hash;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use Sentry\Breadcrumb;
+use Sentry\Integration\IntegrationInterface;
 use Sentry\SentrySdk;
 use Sentry\Severity;
 use Sentry\State\Hub;
@@ -101,15 +102,39 @@ class Client
      */
     protected function setupClient(): void
     {
+        $integrationConfig = (array)Configure::consume('Sentry.integrations');
         $config = (array)Configure::read('Sentry');
         if (!Hash::check($config, 'dsn')) {
             throw new RuntimeException('Sentry DSN not provided.');
         }
+
+        $config += ['integrations' => $this->buildIntegrations($integrationConfig)];
 
         init($config);
         $this->hub = SentrySdk::getCurrentHub();
 
         $event = new Event('CakeSentry.Client.afterSetup', $this);
         $this->getEventManager()->dispatch($event);
+    }
+
+    /**
+     * Build configured integrations
+     *
+     * Config should be written as `Sentry.integrations`.
+     * The content is in the following form
+     * key: IntegrationClassName, value: Options
+     *
+     * @example $integrationConfig = [IgnoreErrorsIntegration => ['ignore_exceptions' => \RuntimeException::class]]
+     * @param array<string, array> $integrationConfig
+     * @return array<IntegrationInterface>
+     */
+    protected function buildIntegrations(array $integrationConfig): array
+    {
+        $integrations = [];
+        foreach ($integrationConfig as $integration => $options) {
+            $integrations[] = new $integration($options);
+        }
+
+        return $integrations;
     }
 }

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -143,7 +143,7 @@ final class ClientTest extends TestCase
 
         $sentryClientP
             ->captureException($exception, Argument::type(Scope::class), null)
-            ->shouldHaveBeenCalled();
+            ->shouldHaveBeenCalledOnce();
     }
 
     /**
@@ -155,7 +155,7 @@ final class ClientTest extends TestCase
     {
         $subject = new Client([]);
         $sentryClientP = $this->prophesize(ClientInterface::class);
-        $sentryClientP->getOptions()->shouldBeCalled()->willReturn(new Options());
+        $sentryClientP->getOptions()->willReturn(new Options());
         $sentryClientP
             ->captureMessage(
                 'some error',
@@ -163,7 +163,7 @@ final class ClientTest extends TestCase
                 Argument::type(Scope::class),
                 null
             )
-            ->shouldBeCalled()
+            ->shouldBeCalledOnce()
             ->willReturn(EventId::generate());
             // NOTE:
             // This itself is not of interest for the test case,
@@ -214,7 +214,7 @@ final class ClientTest extends TestCase
 
         $subject = new Client([]);
         $sentryClientP = $this->prophesize(ClientInterface::class);
-        $sentryClientP->getOptions()->shouldBeCalled()->willReturn(new Options());
+        $sentryClientP->getOptions()->willReturn(new Options());
         $sentryClientP
             ->captureMessage(
                 Argument::any(),
@@ -234,7 +234,7 @@ final class ClientTest extends TestCase
                 }),
                 null
             )
-            ->shouldBeCalled()
+            ->shouldBeCalledOnce()
             ->willReturn(EventId::generate());
             // NOTE:
             // This itself is not of interest for the test case,
@@ -277,7 +277,7 @@ final class ClientTest extends TestCase
         $subject = new Client([]);
         $sentryClientP = $this->prophesize(ClientInterface::class);
         $sentryClientP->captureException(Argument::cetera())
-            ->shouldBeCalled()
+            ->shouldBeCalledOnce()
             ->willReturn($lastEventId);
         $subject->getHub()->bindClient($sentryClientP->reveal());
 

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -78,7 +78,7 @@ final class ClientTest extends TestCase
         Configure::write('Sentry.integrations', [
             IgnoreErrorsIntegration::class => [
                 'ignore_exceptions' => $ignoreErrors,
-            ]
+            ],
         ]);
 
         $subject = new Client([]);
@@ -89,7 +89,6 @@ final class ClientTest extends TestCase
         $actualIntegrationOption = $actualIntegrationProperty->getValue($actualIntegration);
 
         $this->assertSame($ignoreErrors, $actualIntegrationOption['ignore_exceptions']);
-
     }
 
     /**
@@ -184,7 +183,6 @@ final class ClientTest extends TestCase
      * Test capture error compatible with  the error-level is specified by int or string
      *
      * @depends testCaptureError
-     *
      * @param array&array<string,MethodProphecy[]> $mockMethodList
      */
     public function testCaptureErrorWithErrorLevelInteger(array $mockMethodList): void

--- a/tests/test_app/app/composer.json
+++ b/tests/test_app/app/composer.json
@@ -24,7 +24,8 @@
         "cakephp/debug_kit": "^4.0",
         "josegonzalez/dotenv": "^3.2",
         "phpunit/phpunit": "^8.5",
-        "psy/psysh": "@stable"
+        "psy/psysh": "@stable",
+        "symfony/http-client": "^5.2"
     },
     "suggest": {
         "markstory/asset_compress": "An asset compression plugin which provides file concatenation and a flexible filter system for preprocessing and minification.",

--- a/tests/test_app/app/config/bootstrap.php
+++ b/tests/test_app/app/config/bootstrap.php
@@ -79,6 +79,7 @@ if (!env('APP_NAME') && file_exists(CONFIG . '.env')) {
 try {
     Configure::config('default', new PhpConfig());
     Configure::load('app', 'default', false);
+    Configure::load('sentry', 'default');
 } catch (\Exception $e) {
     exit($e->getMessage() . "\n");
 }

--- a/tests/test_app/app/config/sentry.php
+++ b/tests/test_app/app/config/sentry.php
@@ -1,0 +1,17 @@
+<?php
+
+use Cake\Http\Exception\NotFoundException;
+use Sentry\Integration\IgnoreErrorsIntegration;
+
+return [
+    'Sentry' => [
+        'dsn' => env('SENTRY_DSN'),
+        'integrations' => [
+            IgnoreErrorsIntegration::class => [
+                'ignore_exceptions' => [
+                    NotFoundException::class,
+                ],
+            ],
+        ],
+    ],
+];


### PR DESCRIPTION
# Purpose
To make cake-sentry compatible with PHP 8.0, we will first make a major upgrade of the Sentry SDK.
This will allow for disruptive changes to cake-sentry itself, as it will involve significant changes to the internal structure, and thus we will be working towards a new major version "4.0".

see: https://github.com/getsentry/sentry-php/pull/1087

For more information about 4.0, please refer to Milestones
https://github.com/Connehito/cake-sentry/milestone/3

# Changes in this PR
* Update sentry/sentry: ^3.0
* To take advantage of the Sentry SDK's dependence on an abstract HTTP client, cake-sentry itself no longer requires the guzzle adapter
    * Users can use the client of their own choice.
    * ref: #53
* The IgnoreException rule configuration has been changed to be based on IntegrationInterface