### PR TITLE
Adapt to PHP8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
 
 before_script:
   - phpenv config-rm xdebug.ini
+  - echo "assert.exception = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - if [[ $TRAVIS_PHP_VERSION = 7.2 ]]; then composer remove --dev phpspec/prophecy-phpunit; fi
   - composer update --prefer-dist --no-interaction $PREFER_LOWEST
   - composer show -i

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 cache:
   directories:
@@ -15,9 +16,9 @@ env:
 
 matrix:
   include:
-    - php: 7.4
+    - php: 8.0
       env: PREFER_LOWEST="" TEST=1 CODECOV=1 STAN=0
-    - php: 7.4
+    - php: 8.0
       env: PREFER_LOWEST="" TEST=0 CODECOV=0 STAN=1
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
 
 before_script:
   - phpenv config-rm xdebug.ini
+  - if [[ $TRAVIS_PHP_VERSION = 7.2 ]]; then composer remove --dev phpspec/prophecy-phpunit; fi
   - composer update --prefer-dist --no-interaction $PREFER_LOWEST
   - composer show -i
   # @see https://github.com/cakephp/cakephp/pull/13567#issuecomment-525844184

--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,15 @@
     "description": "Sentry plugin for CakePHP",
     "type": "cakephp-plugin",
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "cakephp/cakephp": "^4.0",
         "sentry/sentry": "^3.0"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "@stable",
-        "jangregor/phpstan-prophecy": "^0.4.2",
+        "jangregor/phpstan-prophecy": "^0.8",
         "phpstan/phpstan": "@stable",
-        "phpunit/phpunit": "^8.5.0",
+        "phpunit/phpunit": "^8.5 || ^9.3",
         "symfony/http-client": "^5.2"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "require-dev": {
         "cakephp/cakephp-codesniffer": "@stable",
         "jangregor/phpstan-prophecy": "^0.8",
+        "phpspec/prophecy-phpunit": "@stable",
         "phpstan/phpstan": "@stable",
         "phpunit/phpunit": "^8.5 || ^9.3",
         "symfony/http-client": "^5.2"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "@stable",
-        "jangregor/phpstan-prophecy": "^0.8",
+        "jangregor/phpstan-prophecy": "@stable",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "@stable",
         "phpunit/phpunit": "^8.5 || ^9.3",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require-dev": {
         "cakephp/cakephp-codesniffer": "@stable",
         "jangregor/phpstan-prophecy": "^0.8",
-        "phpspec/prophecy-phpunit": "@stable",
+        "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "@stable",
         "phpunit/phpunit": "^8.5 || ^9.3",
         "symfony/http-client": "^5.2"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-- vendor/jangregor/phpstan-prophecy/src/extension.neon
+- vendor/jangregor/phpstan-prophecy/extension.neon
 parameters:
     paths:
       - src

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -12,6 +12,7 @@ use Closure;
 use Connehito\CakeSentry\Http\Client;
 use Exception;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\MethodProphecy;
 use ReflectionProperty;
 use RuntimeException;
@@ -25,6 +26,8 @@ use Sentry\State\Scope;
 
 final class ClientTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @inheritDoc
      */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -105,3 +105,19 @@ ini_set('intl.default_locale', 'en_US');
 ini_set('session.gc_divisor', '1');
 
 #loadPHPUnitAliases();
+
+/**
+ * NOTE:
+ * Since PHPUnit 9.x, PHPUnit\Framework\TestCase::prophesize is marked as deprecated.
+ * To work around this issue, you need to use \Prophecy\PhpUnit\ProphecyTrait.
+ * However, this Trait is not supported under PHP 7.3.
+ * Declare a dummy Trait to avoid problems in PREFER_LOWEST mode.
+ */
+if (!trait_exists('\\Prophecy\\PhpUnit\\ProphecyTrait')) {
+    assert(
+        version_compare(phpversion(), '7.3.0') < 0,
+        'If using PHP 7.3 or higher, should install phpspec/prophecy-phpunit'
+    );
+    trait DoNothingTrait{}
+    class_alias(DoNothingTrait::class, '\\Prophecy\\PhpUnit\\ProphecyTrait');
+}

--- a/tests/test_app/Dockerfile.php7
+++ b/tests/test_app/Dockerfile.php7
@@ -1,0 +1,17 @@
+FROM php:7-alpine
+RUN apk add bash icu-dev git
+
+WORKDIR /usr/src/php/ext
+RUN git clone https://github.com/xdebug/xdebug
+RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
+    docker-php-ext-install -j${NPROC} intl xdebug pdo_mysql
+RUN echo -e "zend_extension=xdebug.so\n" \
+        "xdebug.client_host=host.docker.internal\n" \
+        "xdebug.start_with_request=trigger\n" \
+        "xdebug.mode=debug" \
+    > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+COPY tests/test_app/composer-install.sh /usr/bin/composer-install
+RUN composer-install \
+  && mv composer.phar /usr/bin/composer
+WORKDIR /app

--- a/tests/test_app/app/composer.json
+++ b/tests/test_app/app/composer.json
@@ -19,11 +19,11 @@
         "mobiledetect/mobiledetectlib": "^2.8"
     },
     "require-dev": {
-        "cakephp/bake": "^2.0.3",
-        "cakephp/cakephp-codesniffer": "~4.0.0",
-        "cakephp/debug_kit": "^4.0",
-        "josegonzalez/dotenv": "^3.2",
-        "phpunit/phpunit": "^8.5",
+        "cakephp/bake": "@stable",
+        "cakephp/cakephp-codesniffer": "@stable",
+        "cakephp/debug_kit": "@stable",
+        "josegonzalez/dotenv": "@stable",
+        "phpunit/phpunit": "^8.5 || ^9.3",
         "psy/psysh": "@stable",
         "symfony/http-client": "^5.2"
     },

--- a/tests/test_app/docker-compose.yml
+++ b/tests/test_app/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.7"
 services:
-  test-app:
+  test-app: &test-app
     volumes:
       - ../../src:/dist/src
       - ../../config:/dist/config
@@ -16,3 +16,11 @@ services:
       dockerfile: ./tests/test_app/Dockerfile
     command: bash -c "/app/tests/test_app/app/bin/cake server -H 0.0.0.0 -p 80"
     working_dir: /app/tests/test_app/app
+  test-app-php7:
+    <<: *test-app
+    ports:
+      - "8081:80"
+    container_name: cake-sentry-test-app-php7
+    build:
+      context: ../..
+      dockerfile: ./tests/test_app/Dockerfile.php7


### PR DESCRIPTION
#  Purpose
Make cake-sentry possible to use in PHP8 🎉 

# I did
* Modify composer.json to allow PHP8(platform-reqs)
* Run tests with PHP8 on CI
* Use the newer version of PHPUnit and its extension libraries
* Compatibility support for PHP 7.2