### PR TITLE
Logging with context

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "cakephp/cakephp": "^4.0",
-        "sentry/sentry": "^3.0"
+        "sentry/sentry": "^3.2"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "@stable",

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -21,7 +21,16 @@ class Client
     use InstanceConfigTrait;
 
     /* @var array default instance config */
-    protected $_defaultConfig = [];
+    protected $_defaultConfig = [
+        'sentry' => [
+            'prefixes' => [
+                APP,
+            ],
+            'in_app_exclude' => [
+                ROOT . DS . 'vendor' . DS,
+            ],
+        ],
+    ];
 
     /* @var Hub */
     protected $hub;
@@ -33,6 +42,10 @@ class Client
      */
     public function __construct(array $config)
     {
+        $userConfig = Configure::read('Sentry');
+        if ($userConfig) {
+            $this->_defaultConfig['sentry'] = array_merge($this->_defaultConfig['sentry'], $userConfig);
+        }
         $this->setConfig($config);
         $this->setupClient();
     }
@@ -97,7 +110,7 @@ class Client
      */
     protected function setupClient(): void
     {
-        $config = (array)Configure::read('Sentry');
+        $config = $this->getConfig('sentry');
         if (!Hash::check($config, 'dsn')) {
             throw new RuntimeException('Sentry DSN not provided.');
         }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -86,11 +86,6 @@ class Client
         if ($exception) {
             $lastEventId = $this->hub->captureException($exception);
         } else {
-            if (is_string($level) && method_exists(Severity::class, $level)) {
-                $severity = (Severity::class . '::' . $level)();
-            } else {
-                $severity = Severity::fromError($level);
-            }
             $hint = new EventHint();
             $hint->extra = $context;
 
@@ -129,5 +124,20 @@ class Client
 
         $event = new Event('CakeSentry.Client.afterSetup', $this);
         $this->getEventManager()->dispatch($event);
+    }
+
+    /**
+     * Convert error info to severity
+     *
+     * @param string|int $level Error name or level(int)
+     * @return \Sentry\Severity
+     */
+    private function convertLevelToSeverity($level): Severity
+    {
+        if (is_string($level) && method_exists(Severity::class, $level)) {
+            return (Severity::class . '::' . $level)();
+        }
+
+        return Severity::fromError($level);
     }
 }

--- a/src/Log/Engine/SentryLog.php
+++ b/src/Log/Engine/SentryLog.php
@@ -28,6 +28,7 @@ class SentryLog extends BaseLog
      */
     public function log($level, $message, array $context = [])
     {
+        $context['stackTrace'] = debug_backtrace();
         $this->client->capture($level, $message, $context);
     }
 }

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -47,6 +47,25 @@ final class ClientTest extends TestCase
     }
 
     /**
+     * Check the configuration values are merged into the default-config.
+     */
+    public function testSetUpClientMergeConfig(): void
+    {
+        $userConfig = [
+            'dsn' => false,
+            'in_app_exclude' => ['/app/vendor', '/app/tmp',],
+            'server_name' => 'test-server',
+        ];
+
+        Configure::write('Sentry', $userConfig);
+        $subject = new Client([]);
+
+        $this->assertSame([APP], $subject->getConfig('sentry.prefixes'), 'Default value not applied');
+        $this->assertSame($userConfig['in_app_exclude'], $subject->getConfig('sentry.in_app_exclude'), 'Default value is not overwritten');
+        $this->assertSame(false, $subject->getConfig('sentry.dsn'), 'Set value is not addes');
+    }
+
+    /**
      * Check constructor throws exception unless dsn is given
      */
     public function testSetupClientNotHasDsn(): void

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -7,7 +7,6 @@ use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
-use Closure;
 use Connehito\CakeSentry\Http\Client;
 use Exception;
 use Prophecy\Argument;
@@ -94,6 +93,11 @@ final class ClientTest extends TestCase
      */
     public function testSetupClientSetSendCallback(): void
     {
+        $callback = function (\Sentry\Event $event, ?\Sentry\EventHint $hint) {
+            return 'this is user callback';
+        };
+        Configure::write('Sentry.before_send', $callback);
+
         $subject = new Client([]);
         $actual = $subject
             ->getHub()
@@ -101,7 +105,10 @@ final class ClientTest extends TestCase
             ->getOptions()
             ->getBeforeSendCallback();
 
-        $this->assertInstanceOf(Closure::class, $actual);
+        $this->assertSame(
+            $callback(\Sentry\Event::createEvent(), null),
+            $actual(\Sentry\Event::createEvent(), null)
+        );
     }
 
     /**

--- a/tests/TestCase/Log/Engine/SentryLogTest.php
+++ b/tests/TestCase/Log/Engine/SentryLogTest.php
@@ -45,7 +45,11 @@ final class SentryLogTest extends TestCase
         $client = $this->getClientProp()->getValue($this->subject);
         $client->expects($this->once())
             ->method('capture')
-            ->with($level, $message, $context);
+            ->with(
+                $level,
+                $message,
+                $this->arrayHasKey('stackTrace')
+            );
 
         $this->subject->log($level, $message, $context);
     }

--- a/tests/test_app/app/config/routes.php
+++ b/tests/test_app/app/config/routes.php
@@ -61,6 +61,7 @@ $routes->scope('/', function (RouteBuilder $builder) {
     $builder->connect('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
     $builder->connect('/error/*', ['controller' => 'Pages', 'action' => 'error']);
     $builder->connect('/exception/*', ['controller' => 'Pages', 'action' => 'exception']);
+    $builder->connect('/log/*', ['controller' => 'Pages', 'action' => 'logging']);
 });
 
 /*

--- a/tests/test_app/app/src/Controller/PagesController.php
+++ b/tests/test_app/app/src/Controller/PagesController.php
@@ -21,6 +21,7 @@ use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
+use Cake\Log\Log;
 use Cake\Utility\Inflector;
 use Cake\View\Exception\MissingTemplateException;
 
@@ -88,6 +89,14 @@ class PagesController extends AppController
         throw new $gottenException($message, $errorCode);
     }
 
+    public function logging(string $errorName)
+    {
+        $message = $this->getRequest()->getQuery('message', 'some error');
+        $this->doLog($errorName, $message);
+
+        $this->render('dump_vars');
+    }
+
     /**
      * Displays a view
      *
@@ -126,5 +135,11 @@ class PagesController extends AppController
             }
             throw new NotFoundException();
         }
+    }
+
+    private function doLog($errorName, string $message)
+    {
+        $this->log($message, $errorName, ['contextual data' => 'with hogehoge']);
+        Log::{$errorName}($message, ['contextual data' => 'with fugafuga']);
     }
 }


### PR DESCRIPTION
# Purpose
Since cake-sentry is implemented as a Logger, it can be used for more than just error logging.
This PR allows us to leave useful information when calling `Logger::log()` directly.

# I did
* Inject a value into the SentrySDK configuration to make it easier to explore the recorded content
    * prefixes,in_app_exclude
    * This makes it possible to distinguish between frames of application code and external library code
* Stop putting them in Breadcrumbs and start treating them as stack trace.
* Raise the minimum Sentry SDK version required to 3.2 in order to simplify the internal implementation.

# Note
The code in this PR uses StacktraceBuilder, which is the class specified in @internal. It may not be appropriate to use this class directly in this plugin.
I made an ill-behaved choice to make the code DRY.