### PR TITLE
Make CakePHP Logger context data to be recorded as extra data

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -72,7 +72,7 @@ class Client
     /**
      * Capture exception for sentry.
      *
-     * @param mixed $level error level
+     * @param string|int $level error level
      * @param string $message error message
      * @param array $context subject
      * @return void

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -87,7 +87,6 @@ class Client
             $lastEventId = $this->hub->captureException($exception);
         } else {
             $hint = new EventHint();
-            $hint->extra = $context;
 
             $stackTrace = $context['stackTrace'] ?? false;
             if ($stackTrace) {
@@ -96,7 +95,11 @@ class Client
                     $stackTrace[0]['file'],
                     $stackTrace[0]['line']
                 );
+                unset($context['stackTrace']);
             }
+            $this->hub->configureScope(function (\Sentry\State\Scope $scope) use ($context) {
+                $scope->setExtras($context);
+            });
 
             $severity = $this->convertLevelToSeverity($level);
             $lastEventId = $this->hub->captureMessage($message, $severity, $hint);

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -244,6 +244,29 @@ final class ClientTest extends TestCase
     }
 
     /**
+     * Test capture error pass cakephp-log's context as additional data
+     */
+    public function testCaptureErrorWithAdditionalData(): void
+    {
+        $callback = function (\Sentry\Event $event, ?\Sentry\EventHint $hint) use (&$actualEvent) {
+            $actualEvent = $event;
+        };
+
+        $userConfig = [
+            'dsn' => false,
+            'before_send' => $callback,
+        ];
+
+        Configure::write('Sentry', $userConfig);
+        $subject = new Client([]);
+
+        $context = ['this is' => 'additional'];
+        $subject->capture('warning', 'some error', $context);
+
+        $this->assertSame($context, $actualEvent->getExtra());
+    }
+
+    /**
      * Check capture dispatch beforeCapture
      */
     public function testCaptureDispatchBeforeCapture(): void

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -151,11 +151,11 @@ final class ClientTest extends TestCase
     }
 
     /**
-     * Test capture error
+     * Test capture other than exception
      *
      * @return array // FIXME: In fact array<string,MethodProphecy[]>, but getMethodProphecies declare as MethodProphecy[]
      */
-    public function testCaptureError(): array
+    public function testCaptureNotHavingException(): array
     {
         $subject = new Client([]);
         $sentryClientP = $this->prophesize(ClientInterface::class);
@@ -185,14 +185,14 @@ final class ClientTest extends TestCase
     }
 
     /**
-     * Test capture error compatible with  the error-level is specified by int or string
+     * Test capture compatible with  the error-level is specified by int or string
      *
-     * @depends testCaptureError
+     * @depends testCaptureNotHavingException
      * @param array&array<string,MethodProphecy[]> $mockMethodList
      */
-    public function testCaptureErrorWithErrorLevelInteger(array $mockMethodList): void
+    public function testCaptureWithErrorLevelInteger(array $mockMethodList): void
     {
-        // Rebuild ObjectProphecy in the same context with testCaptureError.
+        // Rebuild ObjectProphecy in the same context with testCaptureNotHavingException.
         $sentryClientP = $this->prophesize(ClientInterface::class);
         foreach ($mockMethodList as $mockMethod) {
             $sentryClientP->addMethodProphecy($mockMethod[0]);
@@ -205,9 +205,9 @@ final class ClientTest extends TestCase
     }
 
     /**
-     * Test capture error fill with injected breadcrumbs
+     * Test capture fill with injected breadcrumbs
      */
-    public function testCaptureErrorBuildBreadcrumbs(): void
+    public function testCaptureBuildBreadcrumbs(): void
     {
         $stackTrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT);
 
@@ -244,9 +244,9 @@ final class ClientTest extends TestCase
     }
 
     /**
-     * Test capture error pass cakephp-log's context as additional data
+     * Test capture pass cakephp-log's context as additional data
      */
-    public function testCaptureErrorWithAdditionalData(): void
+    public function testCaptureWithAdditionalData(): void
     {
         $callback = function (\Sentry\Event $event, ?\Sentry\EventHint $hint) use (&$actualEvent) {
             $actualEvent = $event;


### PR DESCRIPTION
On calling Log::log() directly, CakePHP allows you to pass a context argument.
In cake-sentry, this information should not be ignored but should be treated as such.

In this PR, it will be sent as extra data.