### PR TITLE
Fix deprecated phpstan's configuration

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,5 +5,5 @@ parameters:
       - src
       - tests/TestCase
     level: 5
-    autoload_files:
+    bootstrapFiles:
       - tests/bootstrap.php


### PR DESCRIPTION
cf) https://phpstan.org/user-guide/discovering-symbols

The following information is displayed when the inspection is run on CI.

```
Note: Using configuration file /home/travis/build/o0h/cake-sentry/phpstan.neon.
⚠️  You're using a deprecated config option autoload_files. ⚠️️
You might not need it anymore - try removing it from your
configuration file and run PHPStan again.
If the analysis fails, there are now two distinct options
to choose from to replace autoload_files:
1) scanFiles - PHPStan will scan those for classes and functions
   definitions. PHPStan will not execute those files.
2) bootstrapFiles - PHPStan will execute these files to prepare
   the PHP runtime environment for the analysis.
Read more about this in PHPStan's documentation:
```